### PR TITLE
hotfix/completed-tasks

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -41,7 +41,7 @@ export default class Home extends React.Component{
         selectedCategory: "Development",
         categories: [],
         currentPage: 0,
-        showCompletedTasks: true,
+        showCompletedTasks: false,
         pullingIssues: false,
         showAmountInCrypto: false,
     }


### PR DESCRIPTION
Right now completed tasks show by default and considering that means only the completed tasks show up by default I changed that behavior. So now only open bounties show up when you refresh the page.