### PR TITLE
Move sinon to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "react-placeholder": "3.0.1",
     "react-router-dom": "4.3.1",
     "react-twitter-conversion-tracker": "^1.0.0",
-    "sinon": "6.3.3",
     "styled-components": "3.4.8"
   },
   "license": "MIT",
@@ -44,6 +43,7 @@
     "cross-env": "5.2.0",
     "enzyme": "3.7.0",
     "enzyme-adapter-react-16": "1.6.0",
-    "jest": "23.6.0"
+    "jest": "23.6.0",
+    "sinon": "6.3.3"
   }
 }


### PR DESCRIPTION
Proposing to move `sinon` into `devDependencies`. It's not used in production code.