### PR TITLE
Normalize PORT envvar name

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
 const express = require('express')
 const next = require('next')
-const port = process.env.prot || 3000;
+const port = process.env.PORT || 3000;
 const dev = process.env.NODE_ENV !== 'production'
 const app = next({ dev })
 const handle = app.getRequestHandler()


### PR DESCRIPTION
Proposal to normalize the environment variable for specifying a custom port.

Normalizes the naming convention into conformance with other envvars present in the code:
* `OFFLINE`
* `NODE_ENV`

Changes the name from `prot` to `PORT`. Usage is like this:
```shell
$ PORT=3500 yarn dev
..
Ready on http://localhost:3500
```